### PR TITLE
Develop

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.permeagility</groupId>
   <artifactId>permeagility</artifactId>
-  <version>0.7.1-SNAPSHOT</version>
+  <version>0.7.1</version>
   <packaging>jar</packaging>
   <name>Permeagility Core</name>
   <description>The dynamic adaptive data management platform</description>
@@ -29,7 +29,7 @@
     <connection>scm:git:https://github.com/PermeAgility/permeagility-core.git</connection>
     <developerConnection>scm:git:https://github.com/PermeAgility/permeagility-core.git</developerConnection>
     <url>git@github.com:PermeAgility/permeagility-core.git</url>
-    <tag>HEAD</tag>
+    <tag>v0.7.1</tag>
   </scm>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.permeagility</groupId>
   <artifactId>permeagility</artifactId>
-  <version>0.7.1</version>
+  <version>0.7.2-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>Permeagility Core</name>
   <description>The dynamic adaptive data management platform</description>
@@ -29,7 +29,7 @@
     <connection>scm:git:https://github.com/PermeAgility/permeagility-core.git</connection>
     <developerConnection>scm:git:https://github.com/PermeAgility/permeagility-core.git</developerConnection>
     <url>git@github.com:PermeAgility/permeagility-core.git</url>
-    <tag>v0.7.1</tag>
+    <tag>HEAD</tag>
   </scm>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -7,6 +7,15 @@
   <name>Permeagility Core</name>
   <description>The dynamic adaptive data management platform</description>
   <url>http://www.permeagility.com</url>
+
+  <properties>
+    <orientdb.version>2.1.11</orientdb.version>
+    <mainClass>permeagility.web.Server</mainClass>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
+  </properties>
+  
   
   <licenses>
     <license>
@@ -40,23 +49,9 @@
   </snapshotRepository>
 </distributionManagement>
   
-  <properties>
-    <mainClass>permeagility.web.Server</mainClass>
-    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
-  </properties>
-  
   <build>
     <sourceDirectory>src</sourceDirectory>
-    <resources>
-      <resource>
-        <directory>www</directory>
-        <excludes>
-          <exclude>**/*.java</exclude>
-        </excludes>
-      </resource>
-    </resources>
+    <resources><resource><directory>www</directory></resource></resources>
     
     <plugins>
           
@@ -149,14 +144,14 @@
     <dependency>
       <groupId>com.orientechnologies</groupId>
       <artifactId>orientdb-core</artifactId>
-      <version>2.1.10</version>
+      <version>${orientdb.version}</version>
     </dependency>
 
     <!-- OrientDB client - for remote connection -->
     <dependency>
       <groupId>com.orientechnologies</groupId>
       <artifactId>orientdb-client</artifactId>
-      <version>2.1.10</version>
+      <version>${orientdb.version}</version>
     </dependency>
 
  </dependencies>

--- a/src/permeagility/util/Setup.java
+++ b/src/permeagility/util/Setup.java
@@ -442,7 +442,7 @@ public class Setup {
             mCount += checkCreateMessage(con, loc, "LOG_VIEW", "View");
             mCount += checkCreateMessage(con, loc, "LOG_FILENAME", "File Name");
             mCount += checkCreateMessage(con, loc, "LOG_SIZE", "Size");
-            mCount += checkCreateMessage(con, loc, "LOG_DATE", "Start Date");
+            mCount += checkCreateMessage(con, loc, "LOG_DATE", "End Date");
             mCount += checkCreateMessage(con, loc, "CHECK_FOR_UPDATE", "Check for update");
             mCount += checkCreateMessage(con, loc, "DOWNLOAD_UPDATE", "Download update");
             mCount += checkCreateMessage(con, loc, "DOWNLOADING_UPDATE", "Downloading");

--- a/src/permeagility/web/Security.java
+++ b/src/permeagility/web/Security.java
@@ -357,7 +357,7 @@ public class Security {
             }            
             return true;
         }
-        return true;
+        return false;
     }
 
 }

--- a/src/permeagility/web/Visuility.java
+++ b/src/permeagility/web/Visuility.java
@@ -24,7 +24,7 @@ public class Visuility extends Weblet {
         String type = parms.get("TYPE");
         String id = parms.get("ID");
         return 	
-            head(Message.get(con.getLocale(), "VISUILITY"),getScript("d3.js"))+
+            head(Message.get(con.getLocale(), "VISUILITY"),getD3Script())+
             body(standardLayout(con, parms,  
                 Schema.getTableSelector(con)
                 +"<button style=\"position: fixed; bottom: 0px;\" id=\"save_as_svg\" download=\"view.svg\">to SVG</button>"

--- a/www/js/visuility.js
+++ b/www/js/visuility.js
@@ -28,8 +28,8 @@ d3.selection.prototype.last = function() {
 var inRectangleSelection = false;
 
 // Database model and data viewer
-var h = $("#chart").height();
-var w = $("#chart").width();
+var w = d3.select("#chart").node().getBoundingClientRect().width;
+var h = d3.select("#chart").node().getBoundingClientRect().height;
 d3.select("#chart").style("cursor", "default");
 var svg = d3.select("#chart").attr("visuilityBuild",true).append("svg").attr("width", w).attr("height", h);
 
@@ -244,7 +244,7 @@ function createFilter() {
 
 function filterGraph(aType, aVisibility) {
   nodeSVG.style("visibility", function (d) {
-    var lOriginalVisibility = $(this).css("visibility");
+    var lOriginalVisibility = d3.select(this).style("visibility");
     return d.type === aType ? aVisibility : lOriginalVisibility;
   });
   updateLinkVisibility();
@@ -701,8 +701,8 @@ function splitLines(text) {
 
 // Setup service resizing and updating the force diagram
 function resize(e){
-    w = $("#chart").width(); 
-    h = $("#chart").height(); 
+    w = d3.select("#chart").node().getBoundingClientRect().width;
+    h = d3.select("#chart").node().getBoundingClientRect().height;
     svg.attr("width", w);
     svg.attr("height", h);
     force.size([w, h]).resume();


### PR DESCRIPTION
- Update to OrientDB 2.1.11
- Visuility is all D3 code now - no longer uses any JQuery functions  (PermeAgility will likely be all D3 in the future or at least mostly D3)
- Visuility will use the min D3 js library based on the flag in the context (defaulted to use min)
- JSON exporter now support SQL results much better - was not handling the different datatypes very well - or at all in many cases
- Was defaulting to readonly on many records if you weren't admin and the table was not ORestricted - default is to assume updatable based on table privileges
